### PR TITLE
font-lock: improve syntax highlighting

### DIFF
--- a/bitbake.el
+++ b/bitbake.el
@@ -714,8 +714,12 @@ For detail, see `comment-dwim'."
 
 (defvar bitbake-font-lock-defaults
   `((
-     ("include\\|require\\|inherit\\|python\\|addtask" . font-lock-keyword-face)
-     ("do_\\(\\s_\\|\\sw\\)+" . font-lock-function-name-face)
+     ;; fakeroot python do_foo() {
+     ("include\\|require\\|inherit\\|python\\|addtask\\|export\\|fakeroot" . font-lock-keyword-face)
+     ;; do_install_append() {
+     ("^\\(fakeroot *\\)?\\(python *\\)?\\([a-zA-Z0-9_${}-]+\\) *( *) *{" 3 font-lock-function-name-face)
+     ;; do_deploy[depends] ??=
+     ("^\\(export *\\)?\\([a-zA-Z0-9_${}-]+\\(\\[[a-zA-Z0-9_-]+\\]\\)?\\) *\\(=\\|\\?=\\|\\?\\?=\\|:=\\|+=\\|=+\\|.=\\|=.\\)" 2 font-lock-variable-name-face)
      )))
 
 (defun bitbake-indent-line ()
@@ -740,17 +744,17 @@ For detail, see `comment-dwim'."
     :submode shell-script-mode
     :delimiter-mode nil
     :case-fold-search nil
-    :front "do_\\(\\s_\\|\\sw\\)+(\\s-*)\\s-*{"
-    :back "}")
+    :front "^\\(fakeroot *\\)?\\([a-zA-Z0-9_${}-]+\\) *( *) *{"
+    :back "^}")
    (bitbake-python
     :submode python-mode
     :delimiter-mode nil
     :case-fold-search nil
-    :front "python\\s-+\\(\\s_\\|\\sw\\)+\\s-*{"
-    :back "}")))
+    :front "^\\(fakeroot *\\)?python *\\([a-zA-Z0-9_${}-]+\\) *( *) *{"
+    :back "^}")))
 
-(mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\'" 'bitbake-shell)
-(mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\'" 'bitbake-python)
+(mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)\\'" 'bitbake-shell)
+(mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)\\'" 'bitbake-python)
 (add-to-list 'auto-mode-alist
              '("\\.bb\\(append\\|class\\)?\\'" . bitbake-mode))
 


### PR DESCRIPTION
Add a number of improvements to syntax highlighting:

- add keywords `export` and `fakeroot`
- make the function regex more general, picking up functions like
  `fakeroot python populate_packages_prepend () {`
- add variable assignment highlighting
- fix `mmm-mode` to no longer end on the first `}` character but instead
  proceed until the end of the function
- enable `mmm-mode` on .bbappend and .bbclass files

----

An easy way to test is to poke around the [openembedded-core source code](http://git.openembedded.org/openembedded-core/tree/meta/classes). Here's before/after screenshots showing the above fixes in action:

## Before
![before](https://user-images.githubusercontent.com/3344958/37137147-6be243fe-2259-11e8-9ee7-3e6e38e34378.png)

## After
![after](https://user-images.githubusercontent.com/3344958/37137270-ef10e460-2259-11e8-8151-459f69fcc806.png)

