### PR TITLE
font-lock: keywords at word boundaries, add unset

### DIFF
--- a/bitbake.el
+++ b/bitbake.el
@@ -715,7 +715,7 @@ For detail, see `comment-dwim'."
 (defvar bitbake-font-lock-defaults
   `((
      ;; fakeroot python do_foo() {
-     ("include\\|require\\|inherit\\|python\\|addtask\\|export\\|fakeroot" . font-lock-keyword-face)
+     ("\\b\\(include\\|require\\|inherit\\|python\\|addtask\\|export\\|fakeroot\\|unset\\)\\b" . font-lock-keyword-face)
      ;; do_install_append() {
      ("^\\(fakeroot *\\)?\\(python *\\)?\\([a-zA-Z0-9_${}-]+\\) *( *) *{" 3 font-lock-function-name-face)
      ;; do_deploy[depends] ??=


### PR DESCRIPTION
Don't highlight this as a keyword:

    libpython_foo += "bar"

Also, `unset` is a keyword.