### PR TITLE
Improve matching of python sections in mmm-mode & change default-tab-width to tab-width

### DIFF
--- a/bitbake.el
+++ b/bitbake.el
@@ -767,7 +767,7 @@ For detail, see `comment-dwim'."
     :case-fold-search nil
     :front ,bitbake-python-def-regex
     :include-front t
-    :back "\\(^[^[:space:]\n]\\)\\|\\'")))
+    :back "\\(^[^[:space:]\n]\\)")))
 
 (defconst bitbake-mode-file-regex "\\.\\(bb\\(append\\|class\\)?\\|inc\\)\\'")
 

--- a/bitbake.el
+++ b/bitbake.el
@@ -383,12 +383,12 @@ If FETCH is non-nil, invalidate cache and fetch the tasks again."
   "Parse bitbake variables BUFFER."
   (with-current-buffer buffer
     (goto-char (point-min))
-    (re-search-forward "^[[:alnum:]_]+()[[:space:]]+{")
+    (re-search-forward "^[[:alnum:]_:]+()[[:space:]]+{")
     (beginning-of-line)
     (let ((limit (point))
           (variables))
       (goto-char (point-min))
-      (while (re-search-forward "^\\([[:alnum:]~+.${}/_-]+\\)=\"\\([^\"]*\\)" limit t)
+      (while (re-search-forward "^\\([[:alnum:]~+.${}/_:-]+\\)=\"\\([^\"]*\\)" limit t)
         (let ((name (substring-no-properties (match-string 1)))
               (value (substring-no-properties (match-string 2))))
           (while (equal (string (char-before)) "\\")
@@ -718,9 +718,9 @@ For detail, see `comment-dwim'."
      ;; fakeroot python do_foo() {
      ("\\b\\(include\\|require\\|inherit\\|python\\|addtask\\|export\\|fakeroot\\|unset\\)\\b" . font-lock-keyword-face)
      ;; do_install_append() {
-     ("^\\(fakeroot *\\)?\\(python *\\)?\\([a-zA-Z0-9\-_+.${}/~]+\\) *( *) *{" 3 font-lock-function-name-face)
+     ("^\\(fakeroot *\\)?\\(python *\\)?\\([a-zA-Z0-9\-_+.${}/~:]+\\) *( *) *{" 3 font-lock-function-name-face)
      ;; do_deploy[depends] ??=
-     ("^\\(export *\\)?\\([a-zA-Z0-9\-_+.${}/~]+\\(\\[[a-zA-Z0-9\-_+.${}/~]+\\]\\)?\\) *\\(=\\|\\?=\\|\\?\\?=\\|:=\\|+=\\|=+\\|.=\\|=.\\)" 2 font-lock-variable-name-face)
+     ("^\\(export *\\)?\\([a-zA-Z0-9\-_+.${}/~]+\\(\\[[a-zA-Z0-9\-_+.${}/~]+\\]\\)?\\(:[a-zA-Z0-9\-_+.${}/~]+\\)?\\) *\\(=\\|\\?=\\|\\?\\?=\\|:=\\|+=\\|=+\\|.=\\|=.\\)" 2 font-lock-variable-name-face)
      )))
 
 (defun bitbake-indent-line ()
@@ -740,8 +740,8 @@ For detail, see `comment-dwim'."
   (set (make-local-variable 'indent-line-function) 'bitbake-indent-line)
   (define-key bitbake-mode-map [remap comment-dwim] 'bitbake-comment-dwim))
 
-(defconst bitbake-shell-regex "^\\(fakeroot[[:space:]]*\\)?\\([a-zA-Z0-9\-_+.${}/~]+\\)[[:space:]]*([[:space:]]*)[[:space:]]*{")
-(defconst bitbake-python-regex "^\\(fakeroot[[:space:]]*\\)?python[[:space:]]*\\([a-zA-Z0-9\-_+.${}/~]+\\)?[[:space:]]*([[:space:]]*)[[:space:]]*{")
+(defconst bitbake-shell-regex "^\\(fakeroot[[:space:]]*\\)?\\([a-zA-Z0-9\-_+.${}/~:]+\\)[[:space:]]*([[:space:]]*)[[:space:]]*{")
+(defconst bitbake-python-regex "^\\(fakeroot[[:space:]]*\\)?python[[:space:]]*\\([a-zA-Z0-9\-_+.${}/~:]+\\)?[[:space:]]*([[:space:]]*)[[:space:]]*{")
 (defconst bitbake-python-def-regex "^def +[a-zA-Z0-9_]+[[:space:]]*([[:space:]a-zA-Z0-9_,=]*)[[:space:]]*:")
 
 (defun bitbake-shell-front-verify ()

--- a/bitbake.el
+++ b/bitbake.el
@@ -742,7 +742,7 @@ For detail, see `comment-dwim'."
 
 (defconst bitbake-shell-regex "^\\(fakeroot[[:space:]]*\\)?\\([a-zA-Z0-9\-_+.${}/~]+\\)[[:space:]]*([[:space:]]*)[[:space:]]*{")
 (defconst bitbake-python-regex "^\\(fakeroot[[:space:]]*\\)?python[[:space:]]*\\([a-zA-Z0-9\-_+.${}/~]+\\)?[[:space:]]*([[:space:]]*)[[:space:]]*{")
-(defconst bitbake-python-def-regex "^def +[a-zA-Z0-9_]+[[:space:]]*([[:space:]a-zA-Z0-9_,]*)[[:space:]]*:")
+(defconst bitbake-python-def-regex "^def +[a-zA-Z0-9_]+[[:space:]]*([[:space:]a-zA-Z0-9_,=]*)[[:space:]]*:")
 
 (defun bitbake-shell-front-verify ()
   (not (string-match bitbake-python-regex (match-string 0))))

--- a/bitbake.el
+++ b/bitbake.el
@@ -728,7 +728,7 @@ For detail, see `comment-dwim'."
   (interactive)
   (beginning-of-line)
   (if (looking-back "\\\\\n")
-      (indent-line-to default-tab-width)
+      (indent-line-to tab-width)
     (indent-line-to 0)))
 
 ;;;###autoload

--- a/bitbake.el
+++ b/bitbake.el
@@ -767,7 +767,7 @@ For detail, see `comment-dwim'."
     :case-fold-search nil
     :front ,bitbake-python-def-regex
     :include-front t
-    :back "^[^[:space:]\n]")))
+    :back "\\(^[^[:space:]\n]\\)\\|\\'")))
 
 (mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)?\\'" 'bitbake-shell)
 (mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)?\\'" 'bitbake-python)

--- a/bitbake.el
+++ b/bitbake.el
@@ -740,22 +740,39 @@ For detail, see `comment-dwim'."
   (set (make-local-variable 'indent-line-function) 'bitbake-indent-line)
   (define-key bitbake-mode-map [remap comment-dwim] 'bitbake-comment-dwim))
 
+(defconst bitbake-shell-regex "^\\(fakeroot[[:space:]]*\\)?\\([a-zA-Z0-9\-_+.${}/~]+\\)[[:space:]]*([[:space:]]*)[[:space:]]*{")
+(defconst bitbake-python-regex "^\\(fakeroot[[:space:]]*\\)?python[[:space:]]*\\([a-zA-Z0-9\-_+.${}/~]+\\)?[[:space:]]*([[:space:]]*)[[:space:]]*{")
+(defconst bitbake-python-def-regex "^def +[a-zA-Z0-9_]+[[:space:]]*([[:space:]a-zA-Z0-9_,]*)[[:space:]]*:")
+
+(defun bitbake-shell-front-verify ()
+  (not (string-match bitbake-python-regex (match-string 0))))
+
 (mmm-add-classes
- '((bitbake-shell
+ `((bitbake-shell
     :submode shell-script-mode
     :delimiter-mode nil
     :case-fold-search nil
-    :front "^\\(fakeroot *\\)?\\([a-zA-Z0-9\-_+.${}/~]+\\) *( *) *{"
+    :front ,bitbake-shell-regex
+    :front-verify bitbake-shell-front-verify
     :back "^}")
    (bitbake-python
     :submode python-mode
     :delimiter-mode nil
     :case-fold-search nil
-    :front "^\\(fakeroot *\\)?python *\\([a-zA-Z0-9\-_+.${}/~]+\\) *( *) *{"
-    :back "^}")))
+    :front ,bitbake-python-regex
+    :back "^}")
+   (bitbake-python-def                  ; matches inline python defs from the def keyword down to the first non-empty non-indented line
+    :submode python-mode
+    :delimiter-mode nil
+    :case-fold-search nil
+    :front ,bitbake-python-def-regex
+    :include-front t
+    :back "^[^[:space:]\n]")))
 
 (mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)?\\'" 'bitbake-shell)
 (mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)?\\'" 'bitbake-python)
+(mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)?\\'" 'bitbake-python-def)
+
 (add-to-list 'auto-mode-alist
              '("\\.bb\\(append\\|class\\)?\\'" . bitbake-mode))
 

--- a/bitbake.el
+++ b/bitbake.el
@@ -769,12 +769,14 @@ For detail, see `comment-dwim'."
     :include-front t
     :back "\\(^[^[:space:]\n]\\)\\|\\'")))
 
-(mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)?\\'" 'bitbake-shell)
-(mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)?\\'" 'bitbake-python)
-(mmm-add-mode-ext-class 'bitbake-mode "\\.bb\\(append\\|class\\)?\\'" 'bitbake-python-def)
+(defconst bitbake-mode-file-regex "\\.\\(bb\\(append\\|class\\)?\\|inc\\)\\'")
+
+(mmm-add-mode-ext-class 'bitbake-mode bitbake-mode-file-regex 'bitbake-shell)
+(mmm-add-mode-ext-class 'bitbake-mode bitbake-mode-file-regex 'bitbake-python)
+(mmm-add-mode-ext-class 'bitbake-mode bitbake-mode-file-regex 'bitbake-python-def)
 
 (add-to-list 'auto-mode-alist
-             '("\\.bb\\(append\\|class\\)?\\'" . bitbake-mode))
+             `(,bitbake-mode-file-regex . bitbake-mode))
 
 (provide 'bitbake)
 


### PR DESCRIPTION
Just some things that occurred to me when I started using this (mostly to get syntax highlighting working ok).

Still a bit of a WIP. There's some more improvement that could be done to use character classes in the existing regexes (like `[:alnum:]`). 

I also get the following warning message directly after switching to `mmm-mode`. This started happening after my changes to matching of `bitbake-shell` and `bitbake-python`:
```
font-lock-fontify-keywords-region: Marker does not point anywhere
```

Despite this warning I don't see any big issues, except fontlock sometimes getting confused around the borders of python regions (but that seems to have been happening before as well), and not updating the syntax highlighting until you modify the code around it a bit.

