### PR TITLE
Match inline python defs at end of buffer

### DIFF
--- a/bitbake.el
+++ b/bitbake.el
@@ -772,7 +772,7 @@ For detail, see `comment-dwim'."
     :case-fold-search nil
     :front ,bitbake-python-def-regex
     :include-front t
-    :back "\\(^[^[:space:]\n]\\)")))
+    :back "\\(^[^[:space:]\n]\\|\\'\\)")))
 
 (defconst bitbake-mode-file-regex "\\.\\(bb\\(append\\|class\\)?\\|inc\\)\\'")
 


### PR DESCRIPTION
Fixes a problem where Python defs at end of buffer aren't recognized unless followed by two `\n` newline characters at the end.

Note that emacs editorconfig mode with will collapse two final newlines into one with `trim_trailing_whitespace = true` set.